### PR TITLE
:sparkles: return error on invalid encoding.

### DIFF
--- a/site_meta.go
+++ b/site_meta.go
@@ -128,11 +128,13 @@ func (meta *SiteMeta) convertEncoding() error {
 		attr.Name, err = converter.ConvertString(attr.Name)
 		if err != nil {
 			logger.Printf("Failed to convert encoding: %s %v\n", attr.Name, err)
+			return err
 		}
 
 		attr.Content, err = converter.ConvertString(attr.Content)
 		if err != nil {
 			logger.Printf("Failed to convert encoding: %s %v\n", attr.Name, err)
+			return err
 		}
 		meta.Attrs[idx] = attr
 	}
@@ -163,8 +165,9 @@ func Parse(url string) (*SiteMeta, error) {
 		}
 	})
 
-	data.convertEncoding()
-
+	if err := data.convertEncoding(); err != nil {
+		return nil, err
+	}
 	if data.IsValid() == false {
 		return nil, nil
 	}

--- a/site_meta_test.go
+++ b/site_meta_test.go
@@ -242,3 +242,23 @@ func TestParseWithNonUTF8ContentUrl(t *testing.T) {
 		}
 	}
 }
+
+func TestParseWithInvalidEncodingUrl(t *testing.T) {
+	examples := []FileExample{
+		FileExample{FileName: "utf8.html", Encoding: "InvalidEncoding"},
+	}
+
+	for _, example := range examples {
+		handler := makeExampleHandler(example)
+		ts := httptest.NewServer(handler)
+		defer ts.Close()
+
+		result, err := Parse(ts.URL)
+		if err == nil {
+			t.Errorf("Error should be thrown.")
+		}
+		if result != nil {
+			t.Errorf("SiteMeta should be nil.")
+		}
+	}
+}


### PR DESCRIPTION
This pull request makes this library return error on failure converting encoding.