### PR TITLE
:sparkles: Use uppcased encoding name

### DIFF
--- a/internal/content/html_content.go
+++ b/internal/content/html_content.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	// DefaultEncoding describe a default encoding.
-	DefaultEncoding string = "utf-8"
+	DefaultEncoding string = "UTF-8"
 )
 
 // HTMLContent describe the html page of the URL.
@@ -41,7 +41,7 @@ func extractCharset(contentType string) string {
 
 	// TODO: Normalize target encoding.
 	logger.Printf("Found charset: %s\n", group[1])
-	return group[1]
+	return strings.ToUpper(group[1])
 }
 
 func parseMetaAttr(key string, s *goquery.Selection) *MetaAttr {
@@ -153,7 +153,7 @@ func (content *HTMLContent) extractCharset() {
 		charset, found := s.Attr("charset")
 		if found {
 			logger.Printf("extractCharset:%s", charset)
-			content.ContentEncoding = charset
+			content.ContentEncoding = strings.ToUpper(charset)
 			return
 		}
 	}

--- a/site_meta.go
+++ b/site_meta.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	// DefaultEncoding describe a default encoding.
-	DefaultEncoding string = "utf-8"
+	DefaultEncoding string = "UTF-8"
 )
 
 // SiteMeta describe meta data of the website, like ogp, TwitterCard.


### PR DESCRIPTION
This library uses [djimenez/iconv-go](https://github.com/djimenez/iconv-go) to convert encoding.

According to `man 3 iconv_open`, Encoding names are described in the upper-cased name.
So this PR change this library to use the upper-cased Encoding name.